### PR TITLE
Update node runtime

### DIFF
--- a/demo/serverless.yml
+++ b/demo/serverless.yml
@@ -2,7 +2,7 @@ service: elm-serverless-demo
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
 
 plugins:
   - serverless-webpack


### PR DESCRIPTION
6.10 is no longer supported for creating new lambdas.  Could/should also change this to `nodejs10.x`, but it seems the preference is for supporting the oldest available version in this project. :)