### PR TITLE
Http 2.0.0

### DIFF
--- a/demo/elm.json
+++ b/demo/elm.json
@@ -8,13 +8,15 @@
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/http": "1.0.0",
+            "elm/core": "1.0.2",
+            "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/url": "1.0.0"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/time": "1.0.0"
         }
     },

--- a/demo/src/Quoted/Models/Quote.elm
+++ b/demo/src/Quoted/Models/Quote.elm
@@ -1,10 +1,11 @@
-module Quoted.Models.Quote exposing (decoder, encodeList, format, request)
+module Quoted.Models.Quote exposing (decodeQuote, encodeList, format, request)
 
 import Http
 import Json.Decode exposing (Decoder, string, succeed)
 import Json.Decode.Pipeline exposing (hardcoded, required)
 import Json.Encode as Encode exposing (Value)
 import Quoted.Types exposing (Quote)
+import Task
 
 
 
@@ -38,18 +39,50 @@ encodeList quotes =
 -- DECODER
 
 
-decoder : String -> Decoder Quote
-decoder lang =
+decodeQuote : String -> Decoder Quote
+decodeQuote lang =
     succeed Quote
         |> hardcoded lang
         |> required "quoteText" string
         |> required "quoteAuthor" string
 
 
-request : String -> Http.Request Quote
+request : String -> Task.Task Http.Error Quote
 request lang =
-    decoder lang
-        |> Http.get
-            ("http://api.forismatic.com/api/1.0/?method=getQuote&format=json&lang="
-                ++ lang
-            )
+    Http.task
+        { method = "GET"
+        , headers = []
+        , url = "http://api.forismatic.com/api/1.0/?method=getQuote&format=json&lang=" ++ lang
+        , body = Http.emptyBody
+        , resolver = jsonResolver (decodeQuote lang)
+        , timeout = Nothing
+        }
+
+
+jsonResolver : Decoder a -> Http.Resolver Http.Error a
+jsonResolver decoder =
+    let
+        resolveToJson : Http.Response String -> Result Http.Error a
+        resolveToJson resp =
+            case resp of
+                Http.BadUrl_ url ->
+                    Err (Http.BadUrl url)
+
+                Http.Timeout_ ->
+                    Err Http.Timeout
+
+                Http.NetworkError_ ->
+                    Err Http.NetworkError
+
+                Http.BadStatus_ metadata body ->
+                    Err (Http.BadStatus metadata.statusCode)
+
+                Http.GoodStatus_ metadata body ->
+                    case Json.Decode.decodeString decoder body of
+                        Ok value ->
+                            Ok value
+
+                        Err err ->
+                            Err (Http.BadBody (Json.Decode.errorToString err))
+    in
+    Http.stringResolver resolveToJson

--- a/demo/src/Quoted/Pipelines/Quote.elm
+++ b/demo/src/Quoted/Pipelines/Quote.elm
@@ -45,7 +45,6 @@ loadQuotes lang conn =
               -- Here we make a request to another service...
               langs
                 |> List.map Quote.request
-                |> List.map Http.toTask
                 |> Task.sequence
                 |> Task.attempt GotQuotes
             )

--- a/elm.json
+++ b/elm.json
@@ -16,13 +16,13 @@
     "dependencies": {
         "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
-        "elm/http": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.1.2 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
+        "elm/random": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm/regex": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/test": "1.2.1 <= v < 2.0.0",
-        "ktonon/elm-test-extra": "2.0.1 <= v < 3.0.0"
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0",
+        "ktonon/elm-test-extra": "2.0.1 <= v < 3.0.0",
+        "elm/regex": "1.0.0 <= v < 2.0.0"
     }
 }


### PR DESCRIPTION
The Http package on elm-serverless was unused. 
So I removed it.

In the demo, Http was being used in a few places. 
I updated the demos to use Http 2.0.0.