### PR TITLE
Fix hot reloading

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -18,6 +18,9 @@ const config = {
       test: /\.elm$/,
       exclude: [/elm-stuff/, /node_modules/],
       loader: 'elm-webpack-loader',
+      options: {
+        forceWatch: true
+      }
     }],
   },
 };


### PR DESCRIPTION
Modified `webpack.config.js` so that hot reloading works for all Elm modules, not just API.elm. This resolves issue #6.